### PR TITLE
Update function el_click

### DIFF
--- a/microne.js
+++ b/microne.js
@@ -100,7 +100,8 @@ function Microne(parent_el) {
 		e.preventDefault()
 
 		if (e.target != t.play_button && t.is_playing) {
-			x = e.pageX - t.el.offsetLeft
+            var rect = t.el.getBoundingClientRect();
+            x = e.pageX - rect.left
 			t.audio.currentTime = t.audio.duration * (x * 100 / t.el.offsetWidth) / 100
 		}
 	}


### PR DESCRIPTION
I ran into a problem here while using the player in a nested element: offsetLeft doesn't always calculate the distance from the edge of the page, sometimes it just calculates the distance to the edge of its parent element (or from the parent element to the edge? I'm not certain). Anyway I believe that the getBoundingClient method I used here is compatible with more contexts — at the very least it fixed the problem I was having.